### PR TITLE
Pin nokogiri >= 1.19.3 (GHSA-c4rq-3m3g-8wgx)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,8 @@ gem 'fastlane-plugin-wpmreleasetoolkit', '~> 12.3'
 #
 # See https://github.com/ruby/openssl/issues/949
 gem 'openssl', '~> 4.0'
+
+# Pinned to pull in the fix for GHSA-c4rq-3m3g-8wgx (CSS selector ReDoS).
+# Drop once `fastlane-plugin-wpmreleasetoolkit` moves to >= 14.4.1, whose
+# gemspec carries this floor transitively.
+gem 'nokogiri', '>= 1.19.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,7 +228,7 @@ GEM
     nanaimo (0.4.0)
     naturally (2.3.0)
     nkf (0.2.0)
-    nokogiri (1.18.3)
+    nokogiri (1.19.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (6.1.1)
@@ -306,6 +306,7 @@ PLATFORMS
 DEPENDENCIES
   fastlane (~> 2.232)
   fastlane-plugin-wpmreleasetoolkit (~> 12.3)
+  nokogiri (>= 1.19.3)
   openssl (~> 4.0)
 
 BUNDLED WITH


### PR DESCRIPTION
<!-- blue -->
> [!NOTE]  
> Closed in favor of #20 

## Summary

Adds `gem 'nokogiri', '>= 1.19.3'` to `Gemfile` to pull in the fix for [GHSA-c4rq-3m3g-8wgx](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-c4rq-3m3g-8wgx) — high-severity ReDoS in Nokogiri's CSS selector tokenizer (vulnerable `< 1.19.3`).

This repo is on `fastlane-plugin-wpmreleasetoolkit ~> 12.3`, which predates the toolkit's own `nokogiri >= 1.19.3` floor (added in 14.4.1). The explicit pin closes the gap without requiring a release-toolkit major bump.

Generated as part of the [nokogiri 1.19.3 Orchard campaign](https://github.a8c.com/mokagio/swiftlint-adoption-orchard-campaign/tree/main/nokogiri-1.19.3-campaign).

## Testing

`bundle install`. `Gemfile.lock` resolves `nokogiri` to `1.19.3`.

---

*Posted by Claude Code (Opus 4.7) on behalf of @mokagio with approval.*