### PR TITLE
Configure Dependabot bundler updates and Ruby review routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Ruby dependency surface
+Gemfile*              @Automattic/apps-infra-tooling
+.bundle/              @Automattic/apps-infra-tooling
+fastlane/             @Automattic/apps-infra-tooling
+
+# CI and automation
+.buildkite/           @Automattic/apps-infra-tooling
+.github/dependabot.yml @Automattic/apps-infra-tooling
+
+# Toolchain and environment pins
+.ruby-version         @Automattic/apps-infra-tooling
+.xcode-version        @Automattic/apps-infra-tooling

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: daily
+    groups:
+      ruby-minor-and-patch:
+        update-types: [minor, patch]
+    open-pull-requests-limit: 5


### PR DESCRIPTION
Sets up Dependabot to check Ruby dependencies daily so we can more easily address security updates. See [AINFRA-2437](https://linear.app/a8c/issue/AINFRA-2437).

Also routes review of the Apps Infra surface (dependency manifests, CI config, toolchain pins) to @Automattic/apps-infra-tooling via CODEOWNERS — GitHub retired the dependabot.yml `reviewers` key, and CODEOWNERS is its designated replacement. The routing is path-based, so it applies to any PR touching those files, not just Dependabot's; deliberate, since no source-scoped alternative exists.

---

Posted by Claude Code, Opus 4.8 (1M context) on behalf of @mokagio.